### PR TITLE
Add new statistic to sussex.cli.grade

### DIFF
--- a/sussex/grades.py
+++ b/sussex/grades.py
@@ -76,4 +76,4 @@ def average_grade():
         reweighted_grades.append(reweighted_grade)
         print('The weighted grade for this module is: \u001b[1m{}%\u001b[0m (\u001b[1m{}%\u001b[0m excluding future)'.format(round(grade, 2), round(reweighted_grade, 2)))
 
-    click.secho('\n\nYou average grade is: {}% ({}% excluding future)'.format(round(sum(grades) / len(grades), 1), round(sum(reweighted_grades) / len(reweighted_grades)) ), bold=True)
+    click.secho('\n\nYour average grade is: {}% ({}% excluding future)'.format(round(sum(grades) / len(grades), 1), round(sum(reweighted_grades) / len(reweighted_grades)) ), bold=True)

--- a/sussex/grades.py
+++ b/sussex/grades.py
@@ -11,6 +11,7 @@ def average_grade():
     page = BeautifulSoup(html, 'lxml')
     grade_links = []
     grades = []
+    reweighted_grades = []
 
     for link in page.find_all('a'):
         try:
@@ -62,11 +63,17 @@ def average_grade():
 
         # Calculate module grade
         grade = 0
-
+        total_weighting = 0
         for a in assessments:
-            grade += a['weight'] * (a['mark_percentage'] / 100)
+            # Mark totals are equal to zero for assignments that have not been marked
+            # So, we should exclude this!
+            if a['mark_total'] > 0:
+                grade += a['weight'] * (a['mark_percentage'] / a['mark_total'])
+                total_weighting += a['weight']
 
         grades.append(grade)
-        print('The weighted grade for this module is: \u001b[1m{}%\u001b[0m'.format(round(grade, 2)))
+        reweighted_grade = (grade / (total_weighting / 100))
+        reweighted_grades.append(reweighted_grade)
+        print('The weighted grade for this module is: \u001b[1m{}%\u001b[0m (\u001b[1m{}%\u001b[0m excluding future)'.format(round(grade, 2), round(reweighted_grade, 2)))
 
-    click.secho('\n\nYou average grade is: {}%'.format(round(sum(grades) / len(grades), 1)), bold=True)
+    click.secho('\n\nYou average grade is: {}% ({}% excluding future)'.format(round(sum(grades) / len(grades), 1), round(sum(reweighted_grades) / len(reweighted_grades)) ), bold=True)


### PR DESCRIPTION
### What?

Provide a new statistic that excludes non-marked assignments in the calculation process, and change the calculation of grades to account for assignments with a maximum grade not equal to 100.

### Why?

When assignments aren't yet released / marked, this counts as a zero mark in the current statistic. What this new statistic provides is weighting based only on the currently marked assignments a person has, allowing them to indicate their current average grade as an indicator of progress.

### How?

The new statistic adds a total_weighting variable, which will sum the total weighting available. With a check for not zero (to prevent 0 / 0 errors), we then divide by the total marks available, and add the weighting. If it is zero, this indicates the assignment is not in the marking stage, so we don't count it in weighting.

### Disclosure of workflow breakages

This does not replace the original statistics, as if a grade has not been released, the original `grade` variable will still be zero. As such, this should not cause any breaking of workflows. Please feel free to comment if it does.

\- val
*valknight.xyz*