### PR TITLE
Fix #6 and repair titling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sussex',
-    version='0.6',
+    version='0.6.1',
     license='MIT',
     author='Simon Sorensen',
     author_email='hello@simse.io',

--- a/sussex/att.py
+++ b/sussex/att.py
@@ -27,22 +27,29 @@ def get_attendance(ignore=[], ignore_optionals=True, print_table=True):
                     while 'Semester' in module_name:
                         module_name = attendance_links[backtrack]['module_name']
                         backtrack -= 1
+                    while 'Autumn' in module_name:
+                        module_name = attendance_links[backtrack]['module_name']
+                        backtrack -= 1
+                    while 'Spring' in module_name:
+                        module_name = attendance_links[backtrack]['module_name']
+                        backtrack -= 1
 
                     backtrack = len(attendance_links) - 1
                     while 'G' not in module_code:
                         module_code = attendance_links[backtrack]['module_code']
                         backtrack -= 1
-
-                    attendance_links.append({
-                        'module_name': module_name,
-                        'module_code': module_code,
-                        'module_id': int(query['rul_code'][0]),
-                        'group_id': int(query['tgo_code'][0]),
-                        'attendance_string': attendance_str,
-                        'total_count': total,
-                        'attended_count': attended,
-                        'percentage': round(attended / total * 100)
-                    })
+                    
+                    if total != 0:
+                        attendance_links.append({
+                            'module_name': module_name,
+                            'module_code': module_code,
+                            'module_id': int(query['rul_code'][0]),
+                            'group_id': int(query['tgo_code'][0]),
+                            'attendance_string': attendance_str,
+                            'total_count': total,
+                            'attended_count': attended,
+                            'percentage': round(attended / total * 100)
+                        })
             except KeyError:
                 pass
 


### PR DESCRIPTION
### What?

Fix division by zero error (#6) , and fix titling for Autumn / Spring labelled items.

### Why?

Previously, sessions with 0/0 available would cause a ZeroDivisionError. We now check for this, and skip a module if it has zero total sessions.

### Disclosure of workflow breakages

This does not make any changes to calculation, as it seems intended behavior was to skip these non-recorded sessions anyway. As such, this should not cause any breaking of workflows. Please feel free to comment if it does.

\- val
*valknight.xyz*